### PR TITLE
Deploy action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,10 @@ jobs:
         uses: actions/checkout@v2.3.1
 
       - name: Install 🏗
-        run: make install VERBOSE=1
+        run: |
+          ls -la
+          make install VERBOSE=1
+          ls -la
 
       - name: Build 🔧
         run: make build VERBOSE=1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,22 @@
+name: Build and Check
+
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+
+      - name: Install 🏗
+        run: make install VERBOSE=1
+
+      - name: Build 🔧
+        run: make build VERBOSE=1
+
+      - name: Check 🕵️‍♀️
+        run: make check VERBOSE=1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Build, Check and Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+
+      - name: Install 🏗
+        run: make install VERBOSE=1
+
+      - name: Build 🔧
+        run: make build VERBOSE=1
+
+      - name: Check 🕵️‍♀️
+        run: make check VERBOSE=1
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: _site # The folder the action should deploy.

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ IGNORE_HREFS=""
 CONFIG=_config.yml
 
 build: install
-	$(DOCKER) bundle exec jekyll build --config $(CONFIG)
+	$(DOCKER) bundle exec jekyll build --trace --config $(CONFIG)
 
 serve: INTERACTIVE=-it
 serve: build
-	$(DOCKER) bundle exec jekyll serve --config $(CONFIG) --host 0.0.0.0 
+	$(DOCKER) bundle exec jekyll serve --config $(CONFIG) --host 0.0.0.0
 
 new:
 	$(DOCKER) bundle exec jekyll new /srv/jekyll/site
@@ -33,7 +33,7 @@ check: build
 		--empty-alt-ignore --allow-hash-href --url-ignore $(IGNORE_HREFS) \
 		--internal_domains "school.pymor.org" --file-ignore "/past/" --check-html
 
-clean: 
+clean:
 	rm -rf _site .cache .jekyll-cache
 
 .PHONY: new serve build clean

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ JEKYLL_VERSION=3.8
 THIS_DIR = $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 DOCKER_CMD=docker
 DOCKER=$(DOCKER_CMD) run $(INTERACTIVE) --rm --label=jekyll --volume $(THIS_DIR):/srv/jekyll \
- 		-v $(THIS_DIR)/.cache:/usr/local/bundle \
+ 		-v $(THIS_DIR)/.cache/bundle:/usr/local/bundle \
 	  -p 127.0.0.1:4000:4000 jekyll/builder:${JEKYLL_VERSION}
 
 IGNORE_HREFS=""

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 JEKYLL_VERSION=3.8
 THIS_DIR = $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 DOCKER_CMD=docker
+JEKYLL_UID=$(shell id -u)
+JEKYLL_GID=$(shell id -g)
 DOCKER=$(DOCKER_CMD) run $(INTERACTIVE) --rm --label=jekyll --volume $(THIS_DIR):/srv/jekyll \
  		-v $(THIS_DIR)/.cache/bundle:/usr/local/bundle \
+		-e JEKYLL_GID=$(JEKYLL_GID) -e JEKYLL_UID=$(JEKYLL_UID) \
 	  -p 127.0.0.1:4000:4000 jekyll/builder:${JEKYLL_VERSION}
 
 IGNORE_HREFS=""


### PR DESCRIPTION
To prevent future straight to master pushes breaking the site I've added gh-actions that run build and check. 
We're also now serving the site from the gh-pages branch (which is pushed to from actions on master). This ensures that only updates on master that have completed CI result in updated pages served to the public. 